### PR TITLE
use resolved version instead of raw version

### DIFF
--- a/src/main/java/q3769/maven/plugins/semver/SemverMojo.java
+++ b/src/main/java/q3769/maven/plugins/semver/SemverMojo.java
@@ -110,7 +110,7 @@ public abstract class SemverMojo extends AbstractMojo {
 
   /** @return original version in pom.xml */
   protected String originalPomVersion() {
-    return project.getOriginalModel().getVersion();
+    return project.getModel().getVersion();
   }
 
   protected void logError(String message, Object... args) {


### PR DESCRIPTION
if a placeholder was used in the project version (e.g. ${myversion}), then the method returned ${myversion} and did not resolve the placeholder